### PR TITLE
Ensure development fallback when build assets are missing

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,5 +1,7 @@
 import express, { type Request, Response, NextFunction } from "express";
 import { createServer } from "http";
+import fs from "fs";
+import path from "path";
 // import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 import { healthRouter, trackRequest } from "./health";
@@ -10,7 +12,7 @@ app.use(express.urlencoded({ extended: false }));
 
 app.use((req, res, next) => {
   const start = Date.now();
-  const path = req.path;
+  const requestPath = req.path;
   let capturedJsonResponse: Record<string, any> | undefined = undefined;
 
   const originalResJson = res.json;
@@ -26,9 +28,9 @@ app.use((req, res, next) => {
     // Track performance metrics for observability
     trackRequest(duration, isError);
     
-    if (path.startsWith("/api")) {
+    if (requestPath.startsWith("/api")) {
       // Safe logging without exposing sensitive response data
-      let logLine = `${req.method} ${path} ${res.statusCode} in ${duration}ms`;
+      let logLine = `${req.method} ${requestPath} ${res.statusCode} in ${duration}ms`;
       
       // Only log response metadata, never actual response bodies to prevent secret exposure
       if (capturedJsonResponse && typeof capturedJsonResponse === 'object') {
@@ -61,15 +63,29 @@ app.use((req, res, next) => {
   // importantly only setup vite in development and after
   // setting up all the other routes so the catch-all route
   // doesn't interfere with the other routes
-  const isDevelopment = process.env.NODE_ENV !== "production";
-  log(`Environment: ${process.env.NODE_ENV || 'not set'}, Running in: ${isDevelopment ? 'DEVELOPMENT' : 'PRODUCTION'} mode`);
-  
-  if (isDevelopment) {
-    log('Setting up Vite development server...');
+  const distPath = path.resolve(import.meta.dirname, "..", "dist", "public");
+  const hasBuiltAssets = fs.existsSync(distPath);
+  const isProductionEnv = process.env.NODE_ENV === "production";
+  const shouldUseDevServer = !isProductionEnv || !hasBuiltAssets;
+
+  log(
+    `Environment: ${process.env.NODE_ENV || "not set"}, Running in: ${
+      shouldUseDevServer ? "DEVELOPMENT" : "PRODUCTION"
+    } mode`,
+  );
+
+  if (shouldUseDevServer) {
+    if (isProductionEnv && !hasBuiltAssets) {
+      log(
+        "Production environment detected but build output missing – falling back to Vite dev server for compatibility.",
+      );
+    }
+
+    log("Setting up Vite development server...");
     await setupVite(app, server);
-    log('Vite development server ready');
+    log("Vite development server ready");
   } else {
-    log('Serving static files from dist...');
+    log("Serving static files from dist...");
     serveStatic(app);
   }
 


### PR DESCRIPTION
## Summary
- detect missing Vite build output before deciding how to serve the client
- fall back to the Vite dev middleware when a production environment lacks built assets to keep lovable.dev previews working
- improve request logging readability by renaming the per-request path variable

## Testing
- npm run check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5daefe9d08330a3aa1c6726549645